### PR TITLE
Add awesome-bot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm: 2.2
+before_script:
+  - gem install awesome_bot
+  - gem install danger
+script:
+  - ruby .github/osia_get_links.rb
+  - awesome_bot check-unique.txt --allow-ssl -a 302 -w xbmc/xbmc,Cherry/master,preyproject
+  - awesome_bot check-links.txt  --allow-ssl -a 403 --allow-dupe -w wheelmap.org,sourceforge,radioparadise,iltofa,douban,preyproject,laravel-china
+after_script:
+  - awesome_bot check-info.txt -a 403
+  - danger

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: ruby
 rvm: 2.2
+cache: bundler
 before_script:
   - gem install awesome_bot
   - gem install danger
 script:
-  - ruby .github/osia_get_links.rb
-  - awesome_bot check-unique.txt --allow-ssl -a 302 -w xbmc/xbmc,Cherry/master,preyproject
-  - awesome_bot check-links.txt  --allow-ssl -a 403 --allow-dupe -w wheelmap.org,sourceforge,radioparadise,iltofa,douban,preyproject,laravel-china
+  - awesome_bot README.md --allow-dupe --allow-ssl --allow 403,429 --allow-redirect -w linkedin
 after_script:
-  - awesome_bot check-info.txt -a 403
-  - danger
+  - danger || exit 0

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,8 @@
+# Check links
+require 'json'
+results = File.read 'ab-results-README.md-markdown-table.json'
+j = JSON.parse results
+if j['error']==true
+  fail j['title']
+  markdown j['message']
+end


### PR DESCRIPTION
Resolves #11 .

This adds automatic link checking with awesome-bot framework ran on travis-ci. 

I have also added optional [danger](https://github.com/danger/danger) support. To enable it, just add your github access token to environment variable named DANGER_GITHUB_API_TOKEN in travis ci pipeline. It needs basic access token permission named `public_repo`. Link for adding tokens: https://github.com/settings/tokens/new