### PR TITLE
add new twitter: SREWeekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,4 +404,5 @@ Contributions are always welcome!
 * [Thomas A. Limoncelli](https://twitter.com/yesthattom)
 * [Todd Underwood](https://twitter.com/tmu)
 * [Twitter SRE](https://twitter.com/TwitterSRE) - The Official Twitter Account of Twitter's SRE team.
+* [Twitter SRE Weekly](https://twitter.com/SREWeekly) - The Official Twitter Account of SRE Weekly Newsletter.
 * [USENIX Association](https://twitter.com/usenix) - The Official USENIX Twitter Account.


### PR DESCRIPTION
This changed add the [SRE Weekly](http://sreweekly.com) [twitter](https://twitter.com/SREWeekly) account managed by [Lex Neva](/lexelby)