### PR TITLE
Link to Kubernetes Failure Stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Contributions are always welcome!
 
 ## Post-Mortem
 * [A collection of post-mortems](https://github.com/danluu/post-mortems)
+* [Collection of Kubernetes Failure Stories](https://github.com/hjacobs/kubernetes-failure-stories)
 * [Blameless PostMortems and a Just Culture](https://codeascraft.com/2012/05/22/blameless-postmortems/)
 * [A Tale of Postmortems](https://blog.box.com/blog/a-tale-of-postmortems/)
 * [Building a Blameless Post-Mortem Culture with Jason Hand](http://runasradio.com/Shows/Show/486)


### PR DESCRIPTION
Adding a link to the list of Kubernetes Failure Stories.

As proposed on https://github.com/dastergon/postmortem-templates/pull/5