### PR TITLE
Removed duplicate entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,6 @@ Contributions are always welcome!
 * [Who's On Call?](http://www.susanjfowler.com/blog/2016/9/6/whos-on-call)
 * [SysAdvent - Day 6 - No More On-Call Martyrs](https://sysadvent.blogspot.com/2016/12/day-6-no-more-on-call-martyrs.html)
 * [On Being On Call](http://naildrivin5.com/blog/2016/12/07/on-call.html)
-* [PagerDuty Incident Response](https://response.pagerduty.com/)
 * [The On-Call Handbook](https://github.com/alicegoldfuss/oncall-handbook)
 * [Incident management at Google — adventures in SRE-land](https://cloudplatform.googleblog.com/2017/02/Incident-management-at-Google-adventures-in-SRE-land.html)
 * [How Spotify and GOV.UK handle on call, and more](https://blog.serverdensity.com/spotify-gov-uk-handle-on-call/)


### PR DESCRIPTION
Removed duplicates - Pagerduty Incident Response and Pagerduty Incident Response handbook both are pointing to the same resource.