### PR TITLE
Fix New to an SRE Team link

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Contributions are always welcome!
 ## Education
 * [Panel: Educating SRE](https://www.usenix.org/conference/srecon15/program/presentation/sebenik)
 * [From Zero to Hero: Recommended Practices for Training your Ever-Evolving SRE Teams](https://www.usenix.org/conference/srecon15/program/presentation/widdowson)
-* [New to an SRE team?](http://anthonycaiafa.com/2016/04/27/new-to-a-team/)
+* [New to an SRE team?](https://web.archive.org/web/20181229031420/http://anthonycaiafa.com/2016/04/27/new-to-a-team/)
 * [The Systems Engineering Side of Site Reliability Engineering](https://www.usenix.org/publications/login/june15/hixson)
 * [Graduating from Bootcamp and interested in becoming a Site Reliability Engineer?](https://medium.com/@tammybutow/graduating-from-bootcamp-and-interested-in-becoming-a-site-reliability-engineer-b69a38ce858b)
 * [So you want to be a Site Reliability Engineer?](https://www.loomsystems.com/single-post/2016/03/23/So-you-want-to-be-a-Site-Reliability-Engineer)


### PR DESCRIPTION
The anthonycaiafa.com website doesn't exist anymore, so I linked it to a
working archive from the Wayback Machine.