### PR TITLE
Add link to blog post on avoiding on-call burnout

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Contributions are always welcome!
 * [Extended Dreyfus Model for Incident Lifecycles](https://github.com/preed/incident-lifecycle-model)
 * [Inhumanity of Root Cause Analysis](https://www.verica.io/inhumanity-of-root-cause-analysis/)
 * [Incident insights from NASA, NTSB, and the CDC](https://www.youtube.com/watch?v=ODYO2MPymJ4)
+* [How to avoid On-Call Burnout the SRE Way](https://blog.squadcast.com/how-to-avoid-on-call-burnout/)
 
 ## Post-Mortem
 * [A collection of post-mortems](https://github.com/danluu/post-mortems)


### PR DESCRIPTION
Adds to literature on avoiding burnouts through -

- setting up effective schedules / rotations across your team and avoiding the "hero" mindset
- smarter routing of incidents through rotations with incident tags that alter routing behavior or trigger automated generic remeditation actions / scripts
- utilising DND mode effectively to coordinate with PTO calendars and other one-off cases to avoid friction and tooling blame
- setting up internal guardrails to promote "No Deploy Fridays" or the equivalent for your team
- enhancing context of incidents by severity tagging and additional live metadata
- mapping out key Service Level Objectives (SLOs) and defining error budgets for every critical service in your service catalog
- actively maintaining an internal knowledge base of key mitigation and resolution steps in a manner as close to code as possible



