### PR TITLE
Add Culture -> "Quick introduction to SRE principles"

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Contributions are always welcome!
 * [From Ops to SRE: Evolution of the OpenShift Dedicated
   Team](https://www.openshift.com/blog/from-ops-to-sre-evolution-of-the-openshift-dedicated-team)
 * [Meeting reliability challenges with SRE principles](https://cloud.google.com/blog/products/management-tools/meeting-reliability-challenges-with-sre-principles)
+* [A quick introduction to SRE principles](https://github.com/fhivemind/sre-playground)
 
 ## Education
 * [Panel: Educating SRE](https://www.usenix.org/conference/srecon15/program/presentation/sebenik)


### PR DESCRIPTION
"Quick introduction to SRE principles" is a short overview and playground article written for everyone trying to start or understand basic Site Reliability Engineering principles. 