### PR TITLE
docs: add SRE cheat sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,3 +533,4 @@ Contributions are always welcome!
 ## SRE Tools
 * [Awesome SRE Tools](https://github.com/SquadcastHub/awesome-sre-tools) - A curated list of Site Reliability and Production Engineering tools
 * [List of Continuous Integration services](https://github.com/ligurio/awesome-ci)
+* [SRE cheat sheet](https://github.com/shibumi/SRE-cheat-sheet) - A cheat sheet for Site Reliability Engineering principles and numbers


### PR DESCRIPTION
This PR adds my SRE cheat sheet to the awesome-SRE README. I am unsure about the exact location. If you prefer a different section/paragraph let me know and I am happy to move it :)

PS: Awesome project. No idea why I missed this in the past. I think I can learn a lot from it. Also like your wheel of misfortune website :)