### PR TITLE
Fixing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Contributions are always welcome!
 * [Case Study: Adopting SRE Principles at StackOverflow](https://www.usenix.org/conference/srecon15/program/presentation/limoncelli)
 * [Site Reliability Engineering at Dropbox](https://www.youtube.com/watch?v=ggizCjUCCqE)
 * [Site Reliability Engineers — Keeping Google up and running 24/7](https://www.youtube.com/watch?v=yXI7r0_J29M)
-* [Site Reliability Engineering at Salesforce](https://www.youtube.com/watch?v=JLkr6UHXN44&nohtml5=False)
+* [Site Reliability Engineering at Salesforce](https://www.salesforce.com/video/193050/)
 * From Sys Admin to Netflix SRE - [video](https://www.youtube.com/watch?v=lZI51YzIgVE) and [slides](https://www.socallinuxexpo.org/sites/default/files/presentations/Scale%20x14%20Slides.pdf)
 * [SRE@Google: Thousands of DevOps Since 2004](https://www.youtube.com/watch?v=iIuTnhdTzK0)
 * [Transactional System Administration Is Killing Us and Must be Stopped](https://www.usenix.org/conference/lisa15/conference-program/presentation/limoncelli)
@@ -58,7 +58,7 @@ Contributions are always welcome!
 * [Work at Google: Meet our Production Engineers for Site Reliability Hangout on Air](https://www.youtube.com/watch?v=bwt6TZjefGM)
 * [Toil: A Word Every Engineer Should Know](https://sharpend.io/toil-a-word-every-engineer-should-know/)
 * [Engineering Reliability into Web Sites: Google SRE](https://research.google.com/pubs/pub32583.html)
-* [DEVOPS & SRE AMA - Building High Performance Organizations](http://pages.catchpoint.com/DEVOPS-SRE-AMA-mkty.html)
+* [DEVOPS & SRE AMA - Building High Performance Organizations](https://vimeo.com/179914447)
 * [John Allspaw's AMA on Incident Analysis and Postmortems](https://community.atlassian.com/t5/Jira-Ops-questions/I-m-John-Allspaw-Ask-Me-Anything-about-incident-analysis-and/qaq-p/957084)
 * Site Reliability Engineering with Paul Newson - [Part 1](https://www.gcppodcast.com/post/episode-38-site-reliability-engineering-with-paul-newson/) & [Part 2](https://gcppodcast.com/post/episode-59-sre-ii-with-paul-newson/)
 * [How SysAdmins Devalue Themselves](https://queue.acm.org/detail.cfm?id=2891413)
@@ -148,7 +148,7 @@ Contributions are always welcome!
 * [What is the role of a Site Reliability Engineer?](https://cloudacademy.com/blog/what-is-the-role-of-a-site-reliability-engineer/)
 * [Lynda.com: DevOps Foundations: Site Reliability Engineering](https://www.lynda.com/Software-Development-tutorials/DevOps-Foundations-Site-Reliability-Engineering/669542-2.html)
 * [Incident Management Training: Wheel of Misfortune](https://dastergon.gr/wheel-of-misfortune/)
-* [Site Un-Reliability Engineering [Video Series]](https://blog.newrelic.com/2018/07/05/site-reliability-engineering-sre/)
+* [Site Un-Reliability Engineering [Video Series]](https://www.youtube.com/watch?v=rmY8_PHanuI)
 * [The Ultimate Guide to Structuring a 90-Day Onboarding Plan](https://medium.com/swlh/the-ultimate-guide-to-structuring-a-90-day-onboarding-plan-c91af947376)
 * [SRE fundamentals: SLIs, SLAs and SLOs](https://cloud.google.com/blog/products/gcp/sre-fundamentals-slis-slas-and-slos)
 * [How to Get Into SRE](https://blog.alicegoldfuss.com/how-to-get-into-sre/)
@@ -163,7 +163,7 @@ Contributions are always welcome!
 * [School of SRE: Curriculum for onboarding non-traditional hires and new grads](https://linkedin.github.io/school-of-sre/)
 
 ## Books
-* [Practical Linux Infrastructure](https://www.apress.com/us/book/9781484205129)
+* [Practical Linux Infrastructure](https://link.springer.com/book/10.1007/978-1-4842-0511-2)
 * [Site Reliability Engineering: How Google Runs Production Systems](https://landing.google.com/sre/book.html)
 * [The Site Reliability Workbook: Practical Ways to Implement SRE](https://landing.google.com/sre/book.html)
 * [Observability Engineering: Achieving Production Excellence](https://info.honeycomb.io/observability-engineering-oreilly-book-2022)
@@ -304,8 +304,8 @@ Contributions are always welcome!
 
 ## On-Call
 * [Being an On-Call Engineer: A Google SRE Perspective](http://research.google.com/pubs/pub44813.html)
-* [Inside Atlassian: how our site reliability engineers do incident management](http://blogs.atlassian.com/2016/02/inside-atlassian-site-reliability-engineers-incident-management/)
-* [Inside Atlassian: how IT & SRE use ChatOps to run incident management](http://blogs.atlassian.com/2016/02/inside-atlassian-sre-use-chatops-run-incident-management/)
+* [Inside Atlassian: how our site reliability engineers do incident management](https://www.atlassian.com/blog/it-teams/inside-atlassian-site-reliability-engineers-incident-management)
+* [Inside Atlassian: how IT & SRE use ChatOps to run incident management](https://www.atlassian.com/blog/2016/02/inside-atlassian-sre-use-chatops-run-incident-management)
 * [Incident Response at Heroku](https://blog.heroku.com/archives/2014/5/9/incident-response-at-heroku)
 * [Who's On Call?](http://www.susanjfowler.com/blog/2016/9/6/whos-on-call)
 * [SysAdvent - Day 6 - No More On-Call Martyrs](https://sysadvent.blogspot.com/2016/12/day-6-no-more-on-call-martyrs.html)
@@ -347,7 +347,7 @@ Contributions are always welcome!
 * [Extended Dreyfus Model for Incident Lifecycles](https://github.com/preed/incident-lifecycle-model)
 * [Inhumanity of Root Cause Analysis](https://www.verica.io/inhumanity-of-root-cause-analysis/)
 * [Incident insights from NASA, NTSB, and the CDC](https://www.youtube.com/watch?v=ODYO2MPymJ4)
-* [How to avoid On-Call Burnout the SRE Way](https://blog.squadcast.com/how-to-avoid-on-call-burnout/)
+* [How to avoid On-Call Burnout the SRE Way](https://www.squadcast.com/blog/how-to-avoid-on-call-burnout)
 * [My week shadowing a GitLab Site Reliability Engineer](https://about.gitlab.com/blog/2019/12/16/sre-shadow/)
 * [How our production team runs the weekly on-call handover](https://about.gitlab.com/blog/2018/03/14/the-on-call-handover-at-gitlab/)
 * [Writing Runbook Documentation When You’re An SRE](https://www.transposit.com/blog/2020.01.30-writing-runbook-documentation-when-youre-an-sre/)
@@ -390,7 +390,7 @@ Contributions are always welcome!
 ## Capacity Planning
 * [Capacity Planning](https://www.usenix.org/system/files/login/articles/login_feb15_07_hixson.pdf)
 * [SouthBay SRE: Cloud Capacity Planning](https://www.youtube.com/watch?v=MDQ0uEUmLOo)
-* [Intent-based Capacity Planning and Autoscaling with Kubernetes](https://blog.squadcast.com/intent-based-capacity-planning-autoscaling-kubernetes/)
+* [Intent-based Capacity Planning and Autoscaling with Kubernetes](https://www.squadcast.com/blog/intent-based-capacity-planning-and-autoscaling-with-kubernetes)
 * [How do you do Capacity Planning](https://jvns.ca/blog/2016/03/20/how-do-you-do-capacity-planning/)
 * [How Back Market SREs prepared for Black Friday](https://medium.com/back-market-engineering/how-back-market-sres-prepared-for-black-friday-5f017f343408)
 
@@ -470,7 +470,6 @@ Contributions are always welcome!
 * [Site Reliability Engineers: “We solve cooler problems”](https://www.google.com/about/careers/stories/site-reliability-engineering-profile-google/)
 * [SREcon17: Brave new world of site reliability engineering](http://www.networkworld.com/article/3182827/cloud-computing/srecon17-brave-new-world-of-site-reliability-engineering.html)
 * [Open AWS guide](https://github.com/open-guides/og-aws)
-* [20 SRE / Devops / System Engineer Tricks](https://twitter.com/i/moments/924656333495898112)
 * [Commentary on Site Reliability Engineering](https://medium.com/@jerub/commentary-on-site-reliability-engineering-9ba9e1be2a8c)
 * [Site Reliability Engineering: 4 Things to Know](https://www.networkcomputing.com/data-centers/site-reliability-engineering-4-things-know/888724300)
 * [Looking for SRE Success? Then Find the Intrapreneurs!](https://www.linkedin.com/pulse/looking-sre-success-find-intrapreneurs-josh-gilliland/)


### PR DESCRIPTION
Last link checker report #149 

Fixing:
✗ [ERR] https://blog.squadcast.com/intent-based-capacity-planning-autoscaling-kubernetes/ | Network error: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1921: (Hostname mismatch)
URL has changed: https://www.squadcast.com/blog/intent-based-capacity-planning-and-autoscaling-with-kubernetes

✗ [404] https://www.youtube.com/watch?v=JLkr6UHXN44&nohtml5=False | Network error: Not Found
Salesforce made it private. I found this one on their website: https://www.salesforce.com/video/193050/

✗ [404] https://blog.newrelic.com/2018/07/05/site-reliability-engineering-sre/ | Network error: Not Found
Page is gone, but the videos are still up. Pointing to the first video of the serie: https://www.youtube.com/watch?v=rmY8_PHanuI

✗ [ERR] https://blog.squadcast.com/how-to-avoid-on-call-burnout/ | Network error: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1921: (Hostname mismatch)
URL has changed: https://www.squadcast.com/blog/how-to-avoid-on-call-burnout

✗ [404] http://pages.catchpoint.com/DEVOPS-SRE-AMA-mkty.html | Network error: Not Found
Video is available on Vimeo: https://vimeo.com/179914447

✗ [ERR] https://www.apress.com/us/book/9781484205129 | Network error: error following redirect for url (https://idp.springer.com/transit?redirect_uri=https%3A%2F%2Flink.springer.com%2Fbook%2F10.1007%2F978-1-4842-0511-2&code=98d2c822-12c6-43b1-9cc2-ab6110bf3d00): too many redirects
Redirect to: https://link.springer.com/book/10.1007/978-1-4842-0511-2

✗ [ERR] http://blogs.atlassian.com/2016/02/inside-atlassian-sre-use-chatops-run-incident-management/ | Network error: error following redirect for url (http://www.atlassian.com/incident-management/devops/chatops): too many redirects
Domain Change: https://www.atlassian.com/blog/2016/02/inside-atlassian-sre-use-chatops-run-incident-management

Also fixed: https://www.atlassian.com/blog/it-teams/inside-atlassian-site-reliability-engineers-incident-management

Deleting:
✗ [404] https://twitter.com/i/moments/924656333495898112 | Network error: Not Found
Tweet doesn't exist anymore. Title was: 20 SRE / Devops / System Engineer Tricks


Left Alone:

✗ [404] https://blog.box.com/blog/a-tale-of-postmortems/ | Network error: Not Found
Cached on Google!

✗ [404] https://twitter.com/The_SRE_Dev | Network error: Not Found
profile is gone, but it was just getting SRE info from dev.to

⧖ [TIMEOUT] https://rachelbythebay.com/w/ | Timeout
It's working here, so it might be some instability. Let's wait for the other ones

✗ [404] https://www.cruform.com/sre-capability-map/ | Network error: Not Found
cruform is now sre path and it asks for your email.

✗ [404] https://www.youtube.com/watch?v=bwt6TZjefGM | Network error: Not Found
Google made it private.