### PR TITLE
Add Palark tech blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Contributions are always welcome!
 * [Rootly Blog](https://www.rootly.io/blog) - Incident management best practices and guides.
 * [incident.io Blog](https://www.incident.io/blog) - Guides, advice and resources on incident management and response.
 * [Logit.io Blog](https://logit.io/blog) - Resources on log management, SRE and devOps.
+* [Palark Tech Blog](https://blog.palark.com/) - Technical articles about SRE & DevOps.
 
 ## Newsletters
 * [DevOpsLinks](https://faun.dev) - A weekly newsletter about SRE, SysAdmin and DevOps news, tools, tutorials and opinions.


### PR DESCRIPTION
[Palark blog](https://blog.palark.com/) is dedicated to Kubernetes, databases, observability, networking, recent failures, etc.