### PR TITLE
Add ReleaseRun Vulnerability Scanner to SRE Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Contributions are always welcome!
 * [Awesome SRE Tools](https://github.com/SquadcastHub/awesome-sre-tools) - A curated list of Site Reliability and Production Engineering tools
 * [List of Continuous Integration services](https://github.com/ligurio/awesome-ci)
 * [SRE cheat sheet](https://github.com/shibumi/SRE-cheat-sheet) - A cheat sheet for Site Reliability Engineering principles and numbers
-* [ReleaseRun](https://releaserun.com/) - Version health monitoring with embeddable EOL, CVE, and freshness badges for 300+ products.
+* [ReleaseRun Vulnerability Scanner](https://releaserun.com/tools/vulnerability-scanner/) - Free dependency scanner that checks your stack for known CVEs and end-of-life versions across 300+ products including Kubernetes, Docker, PostgreSQL, and Node.js.
 
 ## Podcasts
 * [Blameless / Resilience in Action](https://podcasts.apple.com/us/podcast/resilience-in-action/id1506828506)

--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ Contributions are always welcome!
 * [Awesome SRE Tools](https://github.com/SquadcastHub/awesome-sre-tools) - A curated list of Site Reliability and Production Engineering tools
 * [List of Continuous Integration services](https://github.com/ligurio/awesome-ci)
 * [SRE cheat sheet](https://github.com/shibumi/SRE-cheat-sheet) - A cheat sheet for Site Reliability Engineering principles and numbers
+* [ReleaseRun](https://releaserun.com/) - Version health monitoring with embeddable EOL, CVE, and freshness badges for 300+ products.
 
 ## Podcasts
 * [Blameless / Resilience in Action](https://podcasts.apple.com/us/podcast/resilience-in-action/id1506828506)


### PR DESCRIPTION
ReleaseRun's free vulnerability scanner helps SRE teams check their stack for known CVEs and end-of-life versions.

Covers 300+ products including Kubernetes, Docker, PostgreSQL, Node.js, Go, Python, and more. Also available as an npm CLI (`npx releaserun`) for CI/CD pipelines.

Website: https://releaserun.com
Tool: https://releaserun.com/tools/vulnerability-scanner/
CLI: https://www.npmjs.com/package/releaserun