### PR TITLE
Add repo-intel to SRE Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ Contributions are always welcome!
 * [USENIX Association](https://twitter.com/usenix) - The Official USENIX Twitter Account.
 
 ## SRE Tools
+* [repo-intel](https://github.com/oxnr/repo-intel) - AI-powered competitive intelligence GitHub Action. Monitor competitor repos for commit velocity, releases, contributor changes, and strategic signals.
 * [Awesome SRE Tools](https://github.com/SquadcastHub/awesome-sre-tools) - A curated list of Site Reliability and Production Engineering tools
 * [List of Continuous Integration services](https://github.com/ligurio/awesome-ci)
 * [SRE cheat sheet](https://github.com/shibumi/SRE-cheat-sheet) - A cheat sheet for Site Reliability Engineering principles and numbers


### PR DESCRIPTION
## Description

Add [repo-intel](https://github.com/oxnr/repo-intel) to the SRE Tools section.

repo-intel is a GitHub Action that monitors repository activity — commit velocity, release cadence, contributor changes, and issue/PR throughput. SRE teams can use it to track upstream dependency health, monitor open-source projects their infrastructure depends on, and detect activity changes that might signal risk.

Follows the contribution guidelines.