### PR TITLE
Add Uptime SLA Calculator to SRE Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ Contributions are always welcome!
 * [Awesome SRE Tools](https://github.com/SquadcastHub/awesome-sre-tools) - A curated list of Site Reliability and Production Engineering tools
 * [List of Continuous Integration services](https://github.com/ligurio/awesome-ci)
 * [SRE cheat sheet](https://github.com/shibumi/SRE-cheat-sheet) - A cheat sheet for Site Reliability Engineering principles and numbers
+* [Uptime SLA Calculator](https://releaserun.com/uptime-sla-calculator/) - Browser-based calculator for converting uptime targets like 99.9% and 99.99% into allowed downtime windows.
 
 ## Podcasts
 * [Blameless / Resilience in Action](https://podcasts.apple.com/us/podcast/resilience-in-action/id1506828506)


### PR DESCRIPTION
Adds a free browser-based calculator for converting SLA percentages into real downtime budgets.

Useful for on-call planning, incident management, and contract reviews — paste your SLA target (e.g. 99.9%) and get the allowed downtime window per month/quarter/year.

**URL:** https://releaserun.com/uptime-sla-calculator/