### PR TITLE
Add ReleaseRun to monitoring and release tracking tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Contributions are always welcome!
 * [Awesome SRE Tools](https://github.com/SquadcastHub/awesome-sre-tools) - A curated list of Site Reliability and Production Engineering tools
 * [List of Continuous Integration services](https://github.com/ligurio/awesome-ci)
 * [SRE cheat sheet](https://github.com/shibumi/SRE-cheat-sheet) - A cheat sheet for Site Reliability Engineering principles and numbers
-* [ReleaseRun](https://releaserun.com/) - Version health monitoring with embeddable EOL, CVE, and freshness badges for 300+ products.
+* [ReleaseRun Vulnerability Scanner](https://releaserun.com/tools/vulnerability-scanner/) - Free dependency scanner that checks your stack for known CVEs and end-of-life versions across 300+ products including Kubernetes, Docker, PostgreSQL, and Node.js.
 
 ## Podcasts
 * [Blameless / Resilience in Action](https://podcasts.apple.com/us/podcast/resilience-in-action/id1506828506)

--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ Contributions are always welcome!
 * [Awesome SRE Tools](https://github.com/SquadcastHub/awesome-sre-tools) - A curated list of Site Reliability and Production Engineering tools
 * [List of Continuous Integration services](https://github.com/ligurio/awesome-ci)
 * [SRE cheat sheet](https://github.com/shibumi/SRE-cheat-sheet) - A cheat sheet for Site Reliability Engineering principles and numbers
+* [ReleaseRun](https://releaserun.com/) - Version health monitoring with embeddable EOL, CVE, and freshness badges for 300+ products.
 
 ## Podcasts
 * [Blameless / Resilience in Action](https://podcasts.apple.com/us/podcast/resilience-in-action/id1506828506)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 A curated list of awesome [Site Reliability](https://www.usenix.org/conference/srecon14/technical-sessions/presentation/keys-sre) and [Production](https://www.usenix.org/conference/srecon15/program/presentation/canahuati) Engineering resources.
 
+- [ReleaseRun](releaserun.com) — ReleaseRun — tracks software releases, dependency EOL, and version health for SRE teams — free browser-based tools for K8s deprecation checking, dependency audits, and release monitoring
 #### What is Site Reliability Engineering?
 > "Fundamentally, it's what happens when you ask a software engineer to design an operations function." - Ben Treynor Sloss, VP Google Engineering, founder of Google SRE
 
@@ -544,7 +545,6 @@ Contributions are always welcome!
 * [Awesome SRE Tools](https://github.com/SquadcastHub/awesome-sre-tools) - A curated list of Site Reliability and Production Engineering tools
 * [List of Continuous Integration services](https://github.com/ligurio/awesome-ci)
 * [SRE cheat sheet](https://github.com/shibumi/SRE-cheat-sheet) - A cheat sheet for Site Reliability Engineering principles and numbers
-* [ReleaseRun Vulnerability Scanner](https://releaserun.com/tools/vulnerability-scanner/) - Free dependency scanner that checks your stack for known CVEs and end-of-life versions across 300+ products including Kubernetes, Docker, PostgreSQL, and Node.js.
 
 ## Podcasts
 * [Blameless / Resilience in Action](https://podcasts.apple.com/us/podcast/resilience-in-action/id1506828506)


### PR DESCRIPTION
**ReleaseRun** (https://releaserun.com) is a free platform for software release monitoring and dependency health tracking.

It provides browser-based tools for:
- Kubernetes API deprecation checking before cluster upgrades
- Dependency EOL scanning (npm, pip, cargo, gem, composer, go.mod)
- CVE dashboard and release monitoring across 13+ technologies
- Helm chart compatibility checking

Used by DevOps and SRE teams to stay ahead of breaking changes in their stack.